### PR TITLE
Reduced version required for xbmc.python

### DIFF
--- a/service.subtitles.addic7ed/addon.xml
+++ b/service.subtitles.addic7ed/addon.xml
@@ -4,7 +4,7 @@
   version="2.2.1"
   provider-name="Roman V.M.">
 <requires>
-  <import addon="xbmc.python" version="2.25.0"/>
+  <import addon="xbmc.python" version="2.24.0"/>
   <import addon="script.module.beautifulsoup4"/>
   <import addon="script.module.html5lib"/>
   <import addon="script.module.requests"/>


### PR DESCRIPTION
Jarvis would not update the addon, and it complained of unmet dependencies when I installed the update from a zip file.

I tried simply lowering the required version of xbmc.python.
So far I have not seen any problems.